### PR TITLE
TroubleShooting. Optimistic Locking 문제해결

### DIFF
--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/infrastructure/adapter/out/jpa/mapper/JpaMemberMapper.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/infrastructure/adapter/out/jpa/mapper/JpaMemberMapper.kt
@@ -10,7 +10,7 @@ class JpaMemberMapper {
 
     fun fromDomain(member: Member): MemberJpaEntity {
         return MemberJpaEntity(
-            id = member.id ?: 0L,
+            id = member.id,
             username = member.username,
             password = member.password,
             providerType = member.providerType,


### PR DESCRIPTION
## 📝 Outline
- 엔티티 생성 시 Optimistic Locking 에러 발생
  - Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect)

## ⚡️ Reason
- 엔티티 생성 시 Id에 해당하는 `id: Long?` 필드를 null인 경우 0으로 초기화하는 문제

## 🔨 Solve
- mapper의 `?: 0L` 부분을 삭제

## 📓 Note
- `var id: Long? = null` -> OK!
- `var id: Long? = 0L` -> Error!
- `var id: Long = 0L` -> OK!

- JPA가 해당 ID를 통해 새로운 엔티티인지 기존의 엔티티인지 판별하는 과정에서 타입에 따라 다르게 판단한다. 따라서 JPA(혹은 다른 외부 라이브러리)가 어떻게 판단하는 지를 코틀린의 Non-nullable, Nullable 타입을 각각 생각해서 설계하는 것이 중요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 멤버 ID 매핑 처리 개선 및 null 값 처리 로직 정규화

**참고:** 본 변경사항은 내부 시스템 안정성 개선으로, 사용자에게 직접적인 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->