### PR TITLE
Feat. 사용자 권한 변경 API 구현

### DIFF
--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/application/dto/MemberRequestDTO.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/application/dto/MemberRequestDTO.kt
@@ -1,6 +1,8 @@
 package org.jeongmo.migration.member.application.dto
 
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
 import org.jeongmo.migration.common.enums.member.ProviderType
 import org.jeongmo.migration.common.enums.member.Role
 import org.jeongmo.migration.member.domain.model.Member
@@ -40,8 +42,8 @@ data class UpdateMemberRoleRequest(
     /**
      * 수정할 사용자의 id
      */
-    @field:NotBlank
+    @field:Positive
     val userId: Long,
-    @field:NotBlank
+    @field:NotNull
     val role: Role,
 )

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/application/dto/MemberRequestDTO.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/application/dto/MemberRequestDTO.kt
@@ -35,3 +35,13 @@ data class UpdateMemberInfoRequest(
     @field:NotBlank
     val nickname: String,
 )
+
+data class UpdateMemberRoleRequest(
+    /**
+     * 수정할 사용자의 id
+     */
+    @field:NotBlank
+    val userId: Long,
+    @field:NotBlank
+    val role: Role,
+)

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/application/dto/MemberResponseDTO.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/application/dto/MemberResponseDTO.kt
@@ -73,3 +73,22 @@ data class UpdateMemberInfoResponse(
             )
     }
 }
+
+data class UpdateMemberRoleResponse(
+    val id: Long,
+    val username: String,
+    val nickname: String,
+    val role: Role,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun fromDomain(member: Member): UpdateMemberRoleResponse =
+            UpdateMemberRoleResponse(
+                id = member.id,
+                username = member.username,
+                nickname = member.nickname,
+                role = member.role,
+                updatedAt = member.updatedAt ?: LocalDateTime.now(),
+            )
+    }
+}

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/application/error/code/MemberErrorCode.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/application/error/code/MemberErrorCode.kt
@@ -13,6 +13,7 @@ enum class MemberErrorCode(
     INVALID_DATA(HttpStatus.BAD_REQUEST, "MEMBER_400_1", "사용자 유형에 따른 데이터 양식이 맞지 않습니다."),
     INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER_401_1", "비밀번호가 틀렸습니다."),
     ALREADY_DELETE(HttpStatus.BAD_REQUEST, "MEMBER_400_2", "이미 삭제된 사용자입니다."),
+    ALREADY_UPDATE(HttpStatus.BAD_REQUEST,"MEMBER_400_3", "이미 변경되었습니다."),
     CANNOT_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_500_1", "사용자를 삭제할 수 없습니다."),
     ;
 

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/application/port/inbound/MemberCommandUseCase.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/application/port/inbound/MemberCommandUseCase.kt
@@ -31,7 +31,7 @@ interface MemberCommandUseCase {
 
     /**
      * 사용자 역할을 수정하는 메서드
-     * @param id 수정하는 사용자의 ID
+     * @param request 사용자 권한 변경에 필요한 요청
      */
     fun updateMemberRole(request: UpdateMemberRoleRequest): UpdateMemberRoleResponse
 

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/application/port/inbound/MemberCommandUseCase.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/application/port/inbound/MemberCommandUseCase.kt
@@ -30,6 +30,12 @@ interface MemberCommandUseCase {
     fun updateMemberInfos(id: Long, request: UpdateMemberInfoRequest): UpdateMemberInfoResponse
 
     /**
+     * 사용자 역할을 수정하는 메서드
+     * @param id 수정하는 사용자의 ID
+     */
+    fun updateMemberRole(request: UpdateMemberRoleRequest): UpdateMemberRoleResponse
+
+    /**
      * 사용자 삭제 메서드
      * @param id 삭제할 사용자의 ID
      * @throws MemberException 이미 삭제된 사용자의 경우 에러 발생

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/application/service/MemberCommandService.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/application/service/MemberCommandService.kt
@@ -43,8 +43,14 @@ class MemberCommandService(
 
     override fun updateMemberInfos(id: Long, request: UpdateMemberInfoRequest): UpdateMemberInfoResponse {
         val foundMember = memberRepository.findById(id) ?: throw MemberException(MemberErrorCode.NOT_FOUND)
-        val updatedMember = if (foundMember.changeNickname(request.nickname)) memberRepository.save(member = foundMember) else foundMember
-        return UpdateMemberInfoResponse.fromDomain(updatedMember).also { logger.info("[SUCCESS_UPDATE] member-service") }
+        val updatedMember = if (foundMember.changeNickname(request.nickname)) memberRepository.save(member = foundMember) else throw MemberException(MemberErrorCode.ALREADY_UPDATE)
+        return UpdateMemberInfoResponse.fromDomain(updatedMember).also { logger.info("[SUCCESS_UPDATE_INFO] member-service") }
+    }
+
+    override fun updateMemberRole(request: UpdateMemberRoleRequest): UpdateMemberRoleResponse {
+        val foundMember = memberRepository.findById(request.userId) ?: throw MemberException(MemberErrorCode.NOT_FOUND)
+        val updatedMember = if (foundMember.changeRole(request.role)) memberRepository.save(member = foundMember) else throw MemberException(MemberErrorCode.ALREADY_UPDATE)
+        return UpdateMemberRoleResponse.fromDomain(updatedMember).also { logger.info("[SUCCESS_UPDATE_ROLE] member-service") }
     }
 
     override fun deleteMember(id: Long) {

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/domain/model/Member.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/domain/model/Member.kt
@@ -34,4 +34,14 @@ class Member(
         this.nickname = nickname
         return true
     }
+
+    /**
+     * @return 변경되었으면 true, 이미 같은 값이면 false
+     */
+    fun changeRole(role: Role): Boolean {
+        return if (this.role == role) false else {
+            this.role = role
+            true
+        }
+    }
 }

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/infrastructure/adapter/inbound/controller/MemberController.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/infrastructure/adapter/inbound/controller/MemberController.kt
@@ -24,7 +24,7 @@ class MemberController(
         DefaultResponse.ok(memberCommandUseCase.updateMemberInfos(userId, request))
 
     @PatchMapping("/roles")
-    fun updateMemberAuthorities(@RequestBody request: UpdateMemberRoleRequest): DefaultResponse<UpdateMemberRoleResponse> =
+    fun updateMemberAuthorities(@Valid @RequestBody request: UpdateMemberRoleRequest): DefaultResponse<UpdateMemberRoleResponse> =
         DefaultResponse.ok(memberCommandUseCase.updateMemberRole(request))
 
     @DeleteMapping

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/infrastructure/adapter/inbound/controller/MemberController.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/infrastructure/adapter/inbound/controller/MemberController.kt
@@ -2,9 +2,7 @@ package org.jeongmo.migration.member.infrastructure.adapter.inbound.controller
 
 import jakarta.validation.Valid
 import org.jeongmo.migration.common.auth.annotation.LoginUserId
-import org.jeongmo.migration.member.application.dto.MemberInfoResponse
-import org.jeongmo.migration.member.application.dto.UpdateMemberInfoRequest
-import org.jeongmo.migration.member.application.dto.UpdateMemberInfoResponse
+import org.jeongmo.migration.member.application.dto.*
 import org.jeongmo.migration.member.application.port.inbound.MemberCommandUseCase
 import org.jeongmo.migration.member.application.port.inbound.MemberQueryUseCase
 import org.namul.api.payload.response.supports.DefaultResponse
@@ -24,6 +22,10 @@ class MemberController(
     @PatchMapping("/infos")
     fun updateMemberInfo(@LoginUserId userId: Long, @Valid @RequestBody request: UpdateMemberInfoRequest): DefaultResponse<UpdateMemberInfoResponse> =
         DefaultResponse.ok(memberCommandUseCase.updateMemberInfos(userId, request))
+
+    @PatchMapping("/roles")
+    fun updateMemberAuthorities(@RequestBody request: UpdateMemberRoleRequest): DefaultResponse<UpdateMemberRoleResponse> =
+        DefaultResponse.ok(memberCommandUseCase.updateMemberRole(request))
 
     @DeleteMapping
     fun deleteMember(@LoginUserId userId: Long): DefaultResponse<Unit> {

--- a/member-service/src/main/kotlin/org/jeongmo/migration/member/infrastructure/config/security/SecurityConfig.kt
+++ b/member-service/src/main/kotlin/org/jeongmo/migration/member/infrastructure/config/security/SecurityConfig.kt
@@ -34,6 +34,10 @@ class SecurityConfig(
         "/eureka/**",
     )
 
+    private val adminUrl = arrayOf(
+        "/members/roles"
+    )
+
     private val internalServiceUrl = arrayOf(
         "/internal/api/members",
         "/internal/api/members/verify",
@@ -47,6 +51,7 @@ class SecurityConfig(
                 it
                     .requestMatchers(*allowUrl).permitAll()
                     .requestMatchers(*internalServiceUrl).hasRole(Role.INTERNAL_SERVICE.name)
+                    .requestMatchers(*adminUrl).hasRole(Role.ADMIN.name)
                     .anyRequest().authenticated()
             }
             .addFilterAt(authFilter, UsernamePasswordAuthenticationFilter::class.java)


### PR DESCRIPTION
## 📝 Outline
- 사용자 권한 변경 API 구현

## 📓 Changes
- 도메인 내에 사용자 권한 변경 로직 구현
- UseCase 및 서비스 내 사용자 권한 변경 로직 구현
- 컨트롤러 추가 및 ADMIN 권한 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 역할 변경 기능 추가 — 관리자가 특정 사용자의 권한을 변경할 수 있습니다.
  * 역할 변경 결과를 반환하는 응답 형식 추가 및 역할 변경 전용 PATCH 엔드포인트 도입.
  * 역할 변경 엔드포인트는 관리자 권한으로 보호됩니다.

* **Bug Fixes**
  * 변경이 없는 요청에 대해 적절한 오류를 반환하도록 동작 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->